### PR TITLE
build xoop for different shaped screens

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+if [ -z "$1" ]; then
+    cat >&2 <<EOF
+Usage: $0 foo
+  compiles  map_foo.c
+  into      xoop_foo
+
+\$CC overrides the choice of C compiler.
+EOF
+    exit 1
+fi
+
+set -xe
+
+${CC:-cc} -Wall -Wextra -pedantic \
+  -o xoop_$1 xoop.c map_$1.c \
+  -lxcb -lxcb-randr -lxcb-xinput -lxcb-xfixes

--- a/common.h
+++ b/common.h
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <xcb/xfixes.h>
+
+void create_barriers();
+
+void create_barrier(xcb_xfixes_barrier_t *barrier, uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2);
+
+int map(int32_t ev_x, int32_t ev_y, int16_t *x, int16_t *y);
+

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 OUT        = xoop
-SRC 	   = xoop.c
+SRC 	   = xoop.c map_default.c
 CFLAGS 	  += -Wall -Wextra -pedantic -lxcb -lxcb-randr -lxcb-xinput -lxcb-xfixes
 PREFIX    ?= /usr/local
 BINPREFIX ?= $(PREFIX)/bin

--- a/map_default.c
+++ b/map_default.c
@@ -1,0 +1,54 @@
+#include "common.h"
+
+xcb_xfixes_barrier_t    barriers[4];
+
+extern int debug;
+extern int axis;
+extern int16_t width, height;
+extern const int BOTH_AXES;
+extern const int X_ONLY;
+extern const int Y_ONLY;
+
+void create_barriers()
+{
+    uint16_t x1 = 0;
+    uint16_t y1 = 0;
+    uint16_t x2 = width;
+    uint16_t y2 = height;
+
+    if (debug)
+        printf("Creating barriers: %i %i %i %i\n", x1, y1, x2, y2);
+
+    if (axis == X_ONLY || axis == BOTH_AXES) {
+        create_barrier(&barriers[0], x1, y1, x1, y2);
+        create_barrier(&barriers[1], x2, y1, x2, y2);
+    };
+
+    if (axis == Y_ONLY || axis == BOTH_AXES) {
+        create_barrier(&barriers[2], x1, y1, x2, y1);
+        create_barrier(&barriers[3], x1, y2, x2, y2);
+    };
+}
+
+
+int map(int32_t ev_x, int32_t ev_y, int16_t *x, int16_t *y) {
+    int32_t far_x = width - 1;
+    int32_t far_y = height - 1;
+
+    if (ev_x == 0) {
+        *x = far_x;
+        *y = ev_y;
+        return 1;
+    } else if (ev_y == 0){
+        *x = ev_x;
+        *y = far_y;
+        return 1;
+    } else if (ev_x == far_x){
+        *y = ev_y;
+        return 1;
+    } else if (ev_y == far_y){
+        *x = ev_x;
+        return 1;
+    };
+    return 0;
+}

--- a/readme
+++ b/readme
@@ -29,6 +29,12 @@ Arguments
 -h  help
 
 
+Prerequisites
+-------------
+(Ubuntu)
+$ sudo apt install libxcb-randr0-dev libxcb-util-dev libxcb-xfixes0-dev libxcb-xinput-dev
+
+
 To install
 ----------
 


### PR DESCRIPTION
- refactor to define shape and rules in map_* scripts
- script to build xoop_* binary based on named map

Create map_* script to define boundaries and warp rules, and build independent xoop binary for any screen map.

Inspired by screen maps in [taralli](https://github.com/mcdamo/taralli)