### PR TITLE
Fixing build issues

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,7 @@
 OUT        = xoop
-SRC 	   = xoop.c
-CFLAGS 	  += -Wall -Wextra -pedantic -lxcb -lxcb-randr -lxcb-xinput -lxcb-xfixes
+SRC        = xoop.c
+CFLAGS    += -Wall -Wextra -pedantic
+LDLIBS    += -lxcb -lxcb-randr -lxcb-xinput -lxcb-xfixes
 PREFIX    ?= /usr/local
 BINPREFIX ?= $(PREFIX)/bin
 MANPREFIX ?= $(PREFIX)/man/man1

--- a/readme
+++ b/readme
@@ -29,6 +29,18 @@ Arguments
 -h  help
 
 
+Required libraries
+------------------
+
+On Ubuntu 23.10, the following packages are required:
+
+$ sudo apt install \
+    libxcb-randr0-dev \
+    libxcb-util0-dev \
+    libxcb-xfixes0-dev \
+    libxcb-xinput-dev
+
+
 To install
 ----------
 

--- a/xoop.c
+++ b/xoop.c
@@ -50,7 +50,7 @@ int16_t width, height;
 
 void exit_angrily(char msg[])
 {
-    fprintf(stderr, msg);
+    fprintf(stderr, "%s", msg);
     xcb_disconnect(conn);
     exit(EXIT_FAILURE);
 }


### PR DESCRIPTION
Hi,

This is the PR I promised in https://github.com/m-col/xoop/issues/1 .

It contains the following amendments:

- A note about the `xcb` libraries that need to be installed on Ubuntu 23.10.
- Libraries are now listed in `LDLIBS` in the Makefile.
- Amended usage of `fprintf` in `xoop.c:53` (fixes a compiler warning).

Thank you and

Best,
Laurent