### PR TITLE
fix: add signal handler int param

### DIFF
--- a/xoop.c
+++ b/xoop.c
@@ -103,8 +103,9 @@ void delete_barriers()
 }
 
 
-void exit_nicely()
+void exit_nicely(int sig)
 {
+    (void)(sig); // Unused
     delete_barriers();
     xcb_disconnect(conn);
     exit(EXIT_SUCCESS);
@@ -278,6 +279,6 @@ int main(int argc, char *argv[])
 
     event_loop();
 
-    exit_nicely();
+    exit_nicely(0);
     return 0;
 }


### PR DESCRIPTION
the `signal` function takes (void (int)), not (void (void)). This was causing the compilation with gcc to error on my machine. See `man 2 signal`:
`typeof(void (int)) *signal(int signum, typeof(void (int)) *handler);`